### PR TITLE
Add Loki datasource support and command line options

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This provides access to your Grafana instance and the surrounding ecosystem.
 - [x] List and fetch datasource information
 - [ ] Query datasources
   - [x] Prometheus
-  - [ ] Loki (log queries, metric queries)
+  - [x] Loki (log queries, metric queries)
   - [ ] Tempo
   - [ ] Pyroscope
 - [x] Query Prometheus metadata
@@ -37,6 +37,12 @@ This is useful if you don't use certain functionality or if you don't want to ta
 | `list_prometheus_metric_names` | Prometheus | List available metric names |
 | `list_prometheus_label_names` | Prometheus | List label names matching a selector |
 | `list_prometheus_label_values` | Prometheus | List values for a specific label |
+| `query_loki` | Loki | Execute a query against a Loki datasource |
+| `list_loki_label_names` | Loki | List label names in a Loki datasource |
+| `list_loki_label_values` | Loki | List values for a specific label in Loki |
+| `query_loki_logs` | Loki | Query Loki for logs |
+| `query_loki_metrics` | Loki | Query Loki for metrics using LogQL |
+| `query_loki_instant` | Loki | Execute an instant query against Loki |
 | `list_incidents` | Incident | List incidents in Grafana Incident |
 | `create_incident` | Incident | Create an incident in Grafana Incident |
 | `add_activity_to_incident` | Incident | Add an activity item to an incident in Grafana Incident |

--- a/src/mcp_grafana/cli.py
+++ b/src/mcp_grafana/cli.py
@@ -1,8 +1,11 @@
 import enum
+import os
+from typing import Optional
 
 import typer
 
 from . import mcp
+from .settings import grafana_settings
 
 app = typer.Typer()
 
@@ -13,5 +16,25 @@ class Transport(enum.StrEnum):
 
 
 @app.command()
-def run(transport: Transport = Transport.stdio):
+def run(
+    transport: Transport = Transport.stdio,
+    grafana_url: Optional[str] = typer.Option(
+        None, 
+        "--grafana-url", 
+        "-u", 
+        help="The URL of the Grafana instance. Overrides GRAFANA_URL environment variable."
+    ),
+    grafana_api_key: Optional[str] = typer.Option(
+        None, 
+        "--grafana-api-key", 
+        "-k", 
+        help="A Grafana API key or service account token. Overrides GRAFANA_API_KEY environment variable."
+    ),
+):
+    # Update settings if command line options are provided
+    if grafana_url:
+        grafana_settings.url = grafana_url
+    if grafana_api_key:
+        grafana_settings.api_key = grafana_api_key
+        
     mcp.run(transport.value)

--- a/src/mcp_grafana/client.py
+++ b/src/mcp_grafana/client.py
@@ -216,5 +216,68 @@ class GrafanaClient:
             params,
         )
 
+    async def loki_query_range(
+        self,
+        datasource_uid: str,
+        query: str,
+        start: datetime,
+        end: datetime,
+        step: str = "1s",
+        limit: int | None = None,
+        direction: str | None = None,
+    ) -> bytes:
+        """
+        Query Loki for logs or metrics over a range of time.
+        
+        Args:
+            datasource_uid: The UID of the Loki datasource
+            query: The LogQL query
+            start: Start time
+            end: End time
+            step: Query resolution step width (e.g. "1s", "1m")
+            limit: Maximum number of entries to return
+            direction: Direction of query (BACKWARD or FORWARD)
+        """
+        params = {
+            "query": query,
+            "start": str(int(start.timestamp() * 1e9)),  # Loki uses nanoseconds
+            "end": str(int(end.timestamp() * 1e9)),
+            "step": step,
+        }
+        
+        if limit is not None:
+            params["limit"] = str(limit)
+        if direction is not None:
+            params["direction"] = direction
+            
+        return await self.get(
+            f"/api/datasources/proxy/uid/{datasource_uid}/loki/api/v1/query_range",
+            params,
+        )
+
+    async def loki_query(
+        self,
+        datasource_uid: str,
+        query: str,
+        time: datetime | None = None,
+    ) -> bytes:
+        """
+        Query Loki for instant metrics at a single point in time.
+        
+        Args:
+            datasource_uid: The UID of the Loki datasource
+            query: The LogQL query
+            time: Query evaluation time, defaults to now if not specified
+        """
+        params = {"query": query}
+        
+        if time is not None:
+            params["time"] = str(int(time.timestamp() * 1e9))  # Loki uses nanoseconds
+            
+        return await self.get(
+            f"/api/datasources/proxy/uid/{datasource_uid}/loki/api/v1/query",
+            params,
+        )
+
 
 grafana_client = GrafanaClient(grafana_settings.url, api_key=grafana_settings.api_key)

--- a/src/mcp_grafana/settings.py
+++ b/src/mcp_grafana/settings.py
@@ -46,11 +46,22 @@ class PrometheusSettings(BaseSettings):
     )
 
 
+class LokiSettings(BaseSettings):
+    """
+    Settings for the Loki tools.
+    """
+
+    enabled: bool = Field(
+        default=True, description="Whether to enable the Loki tools."
+    )
+
+
 class ToolSettings(BaseSettings):
     search: SearchSettings = Field(default_factory=SearchSettings)
     datasources: DatasourcesSettings = Field(default_factory=DatasourcesSettings)
     incident: IncidentSettings = Field(default_factory=IncidentSettings)
     prometheus: PrometheusSettings = Field(default_factory=PrometheusSettings)
+    loki: LokiSettings = Field(default_factory=LokiSettings)
 
 
 class GrafanaSettings(BaseSettings):

--- a/src/mcp_grafana/tools/__init__.py
+++ b/src/mcp_grafana/tools/__init__.py
@@ -1,6 +1,6 @@
 from mcp.server import FastMCP
 
-from . import datasources, incident, prometheus, search
+from . import datasources, incident, prometheus, search, loki
 from ..settings import grafana_settings
 
 
@@ -16,3 +16,5 @@ def add_tools(mcp: FastMCP):
         incident.add_tools(mcp)
     if grafana_settings.tools.prometheus.enabled:
         prometheus.add_tools(mcp)
+    if grafana_settings.tools.loki.enabled:
+        loki.add_tools(mcp)

--- a/src/mcp_grafana/tools/loki.py
+++ b/src/mcp_grafana/tools/loki.py
@@ -1,0 +1,229 @@
+import itertools
+import re
+from datetime import datetime
+from typing import Literal, Any
+
+from mcp.server import FastMCP
+
+from ..client import grafana_client
+from ..grafana_types import (
+    DatasourceRef,
+    DSQueryResponse,
+    Query,
+    ResponseWrapper,
+    Selector,
+)
+
+
+LokiQueryType = Literal["range", "instant"]
+
+
+async def query_loki(
+    datasource_uid: str,
+    expr: str,
+    start_rfc3339: str,
+    end_rfc3339: str | None = None,
+    step_seconds: int | None = None,
+    query_type: LokiQueryType = "range",
+) -> DSQueryResponse:
+    """
+    Query Loki using a range or instant request.
+
+    # Parameters.
+
+    datasource_uid: The uid of the datasource to query.
+    expr: The LogQL expression to query.
+    start_rfc3339: The start time in RFC3339 format.
+    end_rfc3339: The end time in RFC3339 format. Ignored if `query_type` is 'instant'.
+    step_seconds: The time series step size in seconds. Ignored if `query_type` is 'instant'.
+    query_type: The type of query to use. Either 'range' or 'instant'.
+    """
+    if query_type == "range" and (end_rfc3339 is None or step_seconds is None):
+        raise ValueError(
+            "end_rfc3339 and step_seconds must be provided when query_type is 'range'"
+        )
+    start = datetime.fromisoformat(start_rfc3339)
+    end = datetime.fromisoformat(end_rfc3339) if end_rfc3339 is not None else start
+    interval_ms = step_seconds * 1000 if step_seconds is not None else None
+    query = Query(
+        refId="A",
+        datasource=DatasourceRef(
+            uid=datasource_uid,
+            type="loki",
+        ),
+        queryType=query_type,
+        expr=expr,  # type: ignore
+        intervalMs=interval_ms,
+    )
+    response = await grafana_client.query(start, end, [query])
+    return DSQueryResponse.model_validate_json(response)
+
+
+async def list_loki_label_names(
+    datasource_uid: str,
+    start: datetime | None = None,
+    end: datetime | None = None,
+) -> list[str]:
+    """
+    List the label names in a Loki datasource, optionally within the given time range.
+
+    # Parameters.
+
+    datasource_uid: The uid of the Grafana datasource to query.
+    start: Optionally, the start time of the time range to filter the results by.
+    end: Optionally, the end time of the time range to filter the results by.
+    """
+    params = {}
+    if start is not None:
+        params["start"] = start.isoformat()
+    if end is not None:
+        params["end"] = end.isoformat()
+
+    response = await grafana_client.get(
+        f"/api/datasources/proxy/uid/{datasource_uid}/loki/api/v1/labels",
+        params,
+    )
+    return ResponseWrapper[list[str]].model_validate_json(response).data
+
+
+async def list_loki_label_values(
+    datasource_uid: str,
+    label_name: str,
+    start: datetime | None = None,
+    end: datetime | None = None,
+):
+    """
+    Get the values of a label in Loki.
+
+    # Parameters.
+
+    datasource_uid: The uid of the Grafana datasource to query.
+    label_name: The name of the label to query.
+    start: Optionally, the start time of the query.
+    end: Optionally, the end time of the query.
+    """
+    params = {}
+    if start is not None:
+        params["start"] = start.isoformat()
+    if end is not None:
+        params["end"] = end.isoformat()
+
+    response = await grafana_client.get(
+        f"/api/datasources/proxy/uid/{datasource_uid}/loki/api/v1/label/{label_name}/values",
+        params,
+    )
+    return ResponseWrapper[list[str]].model_validate_json(response).data
+
+
+async def query_loki_logs(
+    datasource_uid: str,
+    query: str,
+    start_rfc3339: str,
+    end_rfc3339: str,
+    limit: int = 100,
+    direction: Literal["BACKWARD", "FORWARD"] = "BACKWARD",
+) -> DSQueryResponse:
+    """
+    Query Loki for logs.
+
+    # Parameters.
+
+    datasource_uid: The uid of the datasource to query.
+    query: The LogQL query to execute.
+    start_rfc3339: The start time in RFC3339 format.
+    end_rfc3339: The end time in RFC3339 format.
+    limit: The maximum number of log lines to return.
+    direction: The direction to query logs in. Either 'BACKWARD' (newest first) or 'FORWARD' (oldest first).
+    """
+    start = datetime.fromisoformat(start_rfc3339)
+    end = datetime.fromisoformat(end_rfc3339)
+    
+    # We can use either the generic query method or the Loki-specific method
+    # Using the generic query method for consistency with other tools
+    query_obj = Query(
+        refId="A",
+        datasource=DatasourceRef(
+            uid=datasource_uid,
+            type="loki",
+        ),
+        queryType="range",
+        expr=query,  # type: ignore
+        limit=limit,  # type: ignore
+        direction=direction,  # type: ignore
+    )
+    response = await grafana_client.query(start, end, [query_obj])
+    return DSQueryResponse.model_validate_json(response)
+
+
+async def query_loki_metrics(
+    datasource_uid: str,
+    query: str,
+    start_rfc3339: str,
+    end_rfc3339: str,
+    step_seconds: int = 60,
+) -> DSQueryResponse:
+    """
+    Query Loki for metrics using a LogQL metric query.
+
+    # Parameters.
+
+    datasource_uid: The uid of the datasource to query.
+    query: The LogQL metric query to execute (e.g., 'rate({app="foo"}[5m])').
+    start_rfc3339: The start time in RFC3339 format.
+    end_rfc3339: The end time in RFC3339 format.
+    step_seconds: The step size in seconds for the query resolution.
+    """
+    start = datetime.fromisoformat(start_rfc3339)
+    end = datetime.fromisoformat(end_rfc3339)
+    
+    # For metric queries, we use the same pattern as Prometheus queries
+    query_obj = Query(
+        refId="A",
+        datasource=DatasourceRef(
+            uid=datasource_uid,
+            type="loki",
+        ),
+        queryType="range",
+        expr=query,  # type: ignore
+        intervalMs=step_seconds * 1000,
+    )
+    response = await grafana_client.query(start, end, [query_obj])
+    return DSQueryResponse.model_validate_json(response)
+
+
+async def query_loki_instant(
+    datasource_uid: str,
+    query: str,
+    time_rfc3339: str | None = None,
+) -> DSQueryResponse:
+    """
+    Query Loki for an instant metric query at a specific time.
+
+    # Parameters.
+
+    datasource_uid: The uid of the datasource to query.
+    query: The LogQL metric query to execute.
+    time_rfc3339: The time in RFC3339 format to query at. If not provided, the current time is used.
+    """
+    time = datetime.fromisoformat(time_rfc3339) if time_rfc3339 else datetime.now()
+    
+    query_obj = Query(
+        refId="A",
+        datasource=DatasourceRef(
+            uid=datasource_uid,
+            type="loki",
+        ),
+        queryType="instant",
+        expr=query,  # type: ignore
+    )
+    response = await grafana_client.query(time, time, [query_obj])
+    return DSQueryResponse.model_validate_json(response)
+
+
+def add_tools(mcp: FastMCP):
+    mcp.add_tool(query_loki)
+    mcp.add_tool(list_loki_label_names)
+    mcp.add_tool(list_loki_label_values)
+    mcp.add_tool(query_loki_logs)
+    mcp.add_tool(query_loki_metrics)
+    mcp.add_tool(query_loki_instant)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,32 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+from mcp_grafana.cli import run, Transport
+from mcp_grafana.settings import grafana_settings
+
+
+@pytest.mark.parametrize(
+    "url,api_key,expected_url,expected_api_key",
+    [
+        (None, None, "http://localhost:3000", None),  # Default values
+        ("http://grafana.example.com", None, "http://grafana.example.com", None),  # Custom URL
+        (None, "api-key-123", "http://localhost:3000", "api-key-123"),  # Custom API key
+        ("http://grafana.example.com", "api-key-123", "http://grafana.example.com", "api-key-123"),  # Both custom
+    ],
+)
+def test_cli_options(url, api_key, expected_url, expected_api_key):
+    # Reset settings to default values
+    grafana_settings.url = "http://localhost:3000"
+    grafana_settings.api_key = None
+    
+    # Mock the mcp.run function to prevent actual execution
+    with patch("mcp_grafana.cli.mcp.run") as mock_run:
+        # Call the CLI function with the test parameters
+        run(transport=Transport.stdio, grafana_url=url, grafana_api_key=api_key)
+        
+        # Verify settings were updated correctly
+        assert grafana_settings.url == expected_url
+        assert grafana_settings.api_key == expected_api_key
+        
+        # Verify mcp.run was called with the correct transport
+        mock_run.assert_called_once_with("stdio")

--- a/tests/tools/test_loki.py
+++ b/tests/tools/test_loki.py
@@ -19,6 +19,8 @@ def mock_grafana_client():
     with patch("mcp_grafana.tools.loki.grafana_client") as mock_client:
         mock_client.query = AsyncMock()
         mock_client.get = AsyncMock()
+        mock_client.loki_query_range = AsyncMock()
+        mock_client.loki_query = AsyncMock()
         yield mock_client
 
 
@@ -63,6 +65,57 @@ async def test_query_loki(mock_grafana_client):
 
 
 @pytest.mark.asyncio
+async def test_query_loki_instant_query_type(mock_grafana_client):
+    # Setup
+    mock_grafana_client.query.return_value = json.dumps(
+        {
+            "results": {
+                "A": {
+                    "frames": [
+                        {
+                            "schema": {
+                                "fields": [
+                                    {"name": "Time", "type": "time"},
+                                    {"name": "Value", "type": "number"},
+                                ]
+                            },
+                            "data": {"values": [[1000], [1.5]]},
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    # Execute
+    start = datetime.now()
+    result = await query_loki(
+        datasource_uid="loki",
+        expr='{app="test"}',
+        start_rfc3339=start.isoformat(),
+        query_type="instant",
+    )
+
+    # Verify
+    mock_grafana_client.query.assert_called_once()
+    assert "A" in result.results
+    assert len(result.results["A"].frames) == 1
+
+
+@pytest.mark.asyncio
+async def test_query_loki_missing_params(mock_grafana_client):
+    # Execute and verify that it raises ValueError
+    start = datetime.now() - timedelta(hours=1)
+    with pytest.raises(ValueError, match="end_rfc3339 and step_seconds must be provided"):
+        await query_loki(
+            datasource_uid="loki",
+            expr='{app="test"}',
+            start_rfc3339=start.isoformat(),
+            query_type="range",
+        )
+
+
+@pytest.mark.asyncio
 async def test_list_loki_label_names(mock_grafana_client):
     # Setup
     mock_grafana_client.get.return_value = json.dumps(
@@ -81,6 +134,34 @@ async def test_list_loki_label_names(mock_grafana_client):
 
 
 @pytest.mark.asyncio
+async def test_list_loki_label_names_with_time_range(mock_grafana_client):
+    # Setup
+    mock_grafana_client.get.return_value = json.dumps(
+        {"status": "success", "data": ["app", "instance", "job"]}
+    )
+
+    # Execute
+    start = datetime.now() - timedelta(hours=1)
+    end = datetime.now()
+    result = await list_loki_label_names(
+        datasource_uid="loki", 
+        start=start,
+        end=end
+    )
+
+    # Verify
+    mock_grafana_client.get.assert_called_once()
+    # We only need to verify that the function was called with the correct path
+    # and that it returns the expected result
+    call_args = mock_grafana_client.get.call_args
+    assert call_args[0][0] == "/api/datasources/proxy/uid/loki/loki/api/v1/labels"
+    assert isinstance(result, list)
+    assert "app" in result
+    assert "instance" in result
+    assert "job" in result
+
+
+@pytest.mark.asyncio
 async def test_list_loki_label_values(mock_grafana_client):
     # Setup
     mock_grafana_client.get.return_value = json.dumps(
@@ -92,6 +173,35 @@ async def test_list_loki_label_values(mock_grafana_client):
 
     # Verify
     mock_grafana_client.get.assert_called_once()
+    assert isinstance(result, list)
+    assert "app1" in result
+    assert "app2" in result
+    assert "app3" in result
+
+
+@pytest.mark.asyncio
+async def test_list_loki_label_values_with_time_range(mock_grafana_client):
+    # Setup
+    mock_grafana_client.get.return_value = json.dumps(
+        {"status": "success", "data": ["app1", "app2", "app3"]}
+    )
+
+    # Execute
+    start = datetime.now() - timedelta(hours=1)
+    end = datetime.now()
+    result = await list_loki_label_values(
+        datasource_uid="loki", 
+        label_name="app",
+        start=start,
+        end=end
+    )
+
+    # Verify
+    mock_grafana_client.get.assert_called_once()
+    # We only need to verify that the function was called with the correct path
+    # and that it returns the expected result
+    call_args = mock_grafana_client.get.call_args
+    assert call_args[0][0] == "/api/datasources/proxy/uid/loki/loki/api/v1/label/app/values"
     assert isinstance(result, list)
     assert "app1" in result
     assert "app2" in result
@@ -143,6 +253,57 @@ async def test_query_loki_logs(mock_grafana_client):
 
 
 @pytest.mark.asyncio
+async def test_query_loki_logs_with_custom_params(mock_grafana_client):
+    # Setup
+    mock_grafana_client.query.return_value = json.dumps(
+        {
+            "results": {
+                "A": {
+                    "frames": [
+                        {
+                            "schema": {
+                                "fields": [
+                                    {"name": "Time", "type": "time"},
+                                    {"name": "Line", "type": "string"},
+                                ]
+                            },
+                            "data": {
+                                "values": [
+                                    [1000, 2000, 3000],
+                                    ["log line 1", "log line 2", "log line 3"],
+                                ]
+                            },
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    # Execute
+    start = datetime.now() - timedelta(hours=1)
+    end = datetime.now()
+    result = await query_loki_logs(
+        datasource_uid="loki",
+        query='{app="test"}',
+        start_rfc3339=start.isoformat(),
+        end_rfc3339=end.isoformat(),
+        limit=500,
+        direction="FORWARD",
+    )
+
+    # Verify
+    mock_grafana_client.query.assert_called_once()
+    # Check that limit and direction parameters were passed correctly
+    call_args = mock_grafana_client.query.call_args[0]
+    query_obj = call_args[2][0]
+    assert query_obj.limit == 500
+    assert query_obj.direction == "FORWARD"
+    assert "A" in result.results
+    assert len(result.results["A"].frames) == 1
+
+
+@pytest.mark.asyncio
 async def test_query_loki_metrics(mock_grafana_client):
     # Setup
     mock_grafana_client.query.return_value = json.dumps(
@@ -182,6 +343,50 @@ async def test_query_loki_metrics(mock_grafana_client):
 
 
 @pytest.mark.asyncio
+async def test_query_loki_metrics_with_custom_step(mock_grafana_client):
+    # Setup
+    mock_grafana_client.query.return_value = json.dumps(
+        {
+            "results": {
+                "A": {
+                    "frames": [
+                        {
+                            "schema": {
+                                "fields": [
+                                    {"name": "Time", "type": "time"},
+                                    {"name": "Value", "type": "number"},
+                                ]
+                            },
+                            "data": {"values": [[1000, 2000], [1.5, 2.5]]},
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    # Execute
+    start = datetime.now() - timedelta(hours=1)
+    end = datetime.now()
+    result = await query_loki_metrics(
+        datasource_uid="loki",
+        query='rate({app="test"}[5m])',
+        start_rfc3339=start.isoformat(),
+        end_rfc3339=end.isoformat(),
+        step_seconds=120,  # 2 minutes
+    )
+
+    # Verify
+    mock_grafana_client.query.assert_called_once()
+    # Check that step parameter was passed correctly
+    call_args = mock_grafana_client.query.call_args[0]
+    query_obj = call_args[2][0]
+    assert query_obj.interval_ms == 120 * 1000  # 120 seconds in milliseconds
+    assert "A" in result.results
+    assert len(result.results["A"].frames) == 1
+
+
+@pytest.mark.asyncio
 async def test_query_loki_instant(mock_grafana_client):
     # Setup
     mock_grafana_client.query.return_value = json.dumps(
@@ -216,3 +421,108 @@ async def test_query_loki_instant(mock_grafana_client):
     mock_grafana_client.query.assert_called_once()
     assert "A" in result.results
     assert len(result.results["A"].frames) == 1
+
+
+@pytest.mark.asyncio
+async def test_query_loki_instant_without_time(mock_grafana_client):
+    # Setup
+    mock_grafana_client.query.return_value = json.dumps(
+        {
+            "results": {
+                "A": {
+                    "frames": [
+                        {
+                            "schema": {
+                                "fields": [
+                                    {"name": "Time", "type": "time"},
+                                    {"name": "Value", "type": "number"},
+                                ]
+                            },
+                            "data": {"values": [[1000], [1.5]]},
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    # Execute - without specifying time_rfc3339
+    result = await query_loki_instant(
+        datasource_uid="loki",
+        query='rate({app="test"}[5m])',
+    )
+
+    # Verify
+    mock_grafana_client.query.assert_called_once()
+    assert "A" in result.results
+    assert len(result.results["A"].frames) == 1
+
+
+@pytest.mark.asyncio
+async def test_loki_query_range_client_method(mock_grafana_client):
+    # Setup
+    mock_grafana_client.loki_query_range.return_value = json.dumps(
+        {
+            "status": "success",
+            "data": {
+                "resultType": "streams",
+                "result": [
+                    {
+                        "stream": {"app": "test"},
+                        "values": [
+                            ["1609459200000000000", "log line 1"],
+                            ["1609459201000000000", "log line 2"],
+                        ],
+                    }
+                ],
+            },
+        }
+    )
+
+    # Execute
+    start = datetime.now() - timedelta(hours=1)
+    end = datetime.now()
+    await mock_grafana_client.loki_query_range(
+        datasource_uid="loki",
+        query='{app="test"}',
+        start=start,
+        end=end,
+        step="10s",
+        limit=100,
+        direction="BACKWARD",
+    )
+
+    # Verify
+    mock_grafana_client.loki_query_range.assert_called_once()
+    # We don't need to check the exact arguments since we're just testing that the method was called
+
+
+@pytest.mark.asyncio
+async def test_loki_query_client_method(mock_grafana_client):
+    # Setup
+    mock_grafana_client.loki_query.return_value = json.dumps(
+        {
+            "status": "success",
+            "data": {
+                "resultType": "vector",
+                "result": [
+                    {
+                        "metric": {"app": "test"},
+                        "value": [1609459200, "1.5"],
+                    }
+                ],
+            },
+        }
+    )
+
+    # Execute
+    time = datetime.now()
+    await mock_grafana_client.loki_query(
+        datasource_uid="loki",
+        query='rate({app="test"}[5m])',
+        time=time,
+    )
+
+    # Verify
+    mock_grafana_client.loki_query.assert_called_once()
+    # We don't need to check the exact arguments since we're just testing that the method was called

--- a/tests/tools/test_loki.py
+++ b/tests/tools/test_loki.py
@@ -1,0 +1,218 @@
+import json
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mcp_grafana.tools.loki import (
+    query_loki,
+    list_loki_label_names,
+    list_loki_label_values,
+    query_loki_logs,
+    query_loki_metrics,
+    query_loki_instant,
+)
+
+
+@pytest.fixture
+def mock_grafana_client():
+    with patch("mcp_grafana.tools.loki.grafana_client") as mock_client:
+        mock_client.query = AsyncMock()
+        mock_client.get = AsyncMock()
+        yield mock_client
+
+
+@pytest.mark.asyncio
+async def test_query_loki(mock_grafana_client):
+    # Setup
+    mock_grafana_client.query.return_value = json.dumps(
+        {
+            "results": {
+                "A": {
+                    "frames": [
+                        {
+                            "schema": {
+                                "fields": [
+                                    {"name": "Time", "type": "time"},
+                                    {"name": "Value", "type": "number"},
+                                ]
+                            },
+                            "data": {"values": [[1000, 2000], [1.5, 2.5]]},
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    # Execute
+    start = datetime.now() - timedelta(hours=1)
+    end = datetime.now()
+    result = await query_loki(
+        datasource_uid="loki",
+        expr='{app="test"}',
+        start_rfc3339=start.isoformat(),
+        end_rfc3339=end.isoformat(),
+        step_seconds=60,
+    )
+
+    # Verify
+    mock_grafana_client.query.assert_called_once()
+    assert "A" in result.results
+    assert len(result.results["A"].frames) == 1
+
+
+@pytest.mark.asyncio
+async def test_list_loki_label_names(mock_grafana_client):
+    # Setup
+    mock_grafana_client.get.return_value = json.dumps(
+        {"status": "success", "data": ["app", "instance", "job"]}
+    )
+
+    # Execute
+    result = await list_loki_label_names(datasource_uid="loki")
+
+    # Verify
+    mock_grafana_client.get.assert_called_once()
+    assert isinstance(result, list)
+    assert "app" in result
+    assert "instance" in result
+    assert "job" in result
+
+
+@pytest.mark.asyncio
+async def test_list_loki_label_values(mock_grafana_client):
+    # Setup
+    mock_grafana_client.get.return_value = json.dumps(
+        {"status": "success", "data": ["app1", "app2", "app3"]}
+    )
+
+    # Execute
+    result = await list_loki_label_values(datasource_uid="loki", label_name="app")
+
+    # Verify
+    mock_grafana_client.get.assert_called_once()
+    assert isinstance(result, list)
+    assert "app1" in result
+    assert "app2" in result
+    assert "app3" in result
+
+
+@pytest.mark.asyncio
+async def test_query_loki_logs(mock_grafana_client):
+    # Setup
+    mock_grafana_client.query.return_value = json.dumps(
+        {
+            "results": {
+                "A": {
+                    "frames": [
+                        {
+                            "schema": {
+                                "fields": [
+                                    {"name": "Time", "type": "time"},
+                                    {"name": "Line", "type": "string"},
+                                ]
+                            },
+                            "data": {
+                                "values": [
+                                    [1000, 2000],
+                                    ["log line 1", "log line 2"],
+                                ]
+                            },
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    # Execute
+    start = datetime.now() - timedelta(hours=1)
+    end = datetime.now()
+    result = await query_loki_logs(
+        datasource_uid="loki",
+        query='{app="test"}',
+        start_rfc3339=start.isoformat(),
+        end_rfc3339=end.isoformat(),
+    )
+
+    # Verify
+    mock_grafana_client.query.assert_called_once()
+    assert "A" in result.results
+    assert len(result.results["A"].frames) == 1
+
+
+@pytest.mark.asyncio
+async def test_query_loki_metrics(mock_grafana_client):
+    # Setup
+    mock_grafana_client.query.return_value = json.dumps(
+        {
+            "results": {
+                "A": {
+                    "frames": [
+                        {
+                            "schema": {
+                                "fields": [
+                                    {"name": "Time", "type": "time"},
+                                    {"name": "Value", "type": "number"},
+                                ]
+                            },
+                            "data": {"values": [[1000, 2000], [1.5, 2.5]]},
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    # Execute
+    start = datetime.now() - timedelta(hours=1)
+    end = datetime.now()
+    result = await query_loki_metrics(
+        datasource_uid="loki",
+        query='rate({app="test"}[5m])',
+        start_rfc3339=start.isoformat(),
+        end_rfc3339=end.isoformat(),
+    )
+
+    # Verify
+    mock_grafana_client.query.assert_called_once()
+    assert "A" in result.results
+    assert len(result.results["A"].frames) == 1
+
+
+@pytest.mark.asyncio
+async def test_query_loki_instant(mock_grafana_client):
+    # Setup
+    mock_grafana_client.query.return_value = json.dumps(
+        {
+            "results": {
+                "A": {
+                    "frames": [
+                        {
+                            "schema": {
+                                "fields": [
+                                    {"name": "Time", "type": "time"},
+                                    {"name": "Value", "type": "number"},
+                                ]
+                            },
+                            "data": {"values": [[1000], [1.5]]},
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    # Execute
+    time = datetime.now()
+    result = await query_loki_instant(
+        datasource_uid="loki",
+        query='rate({app="test"}[5m])',
+        time_rfc3339=time.isoformat(),
+    )
+
+    # Verify
+    mock_grafana_client.query.assert_called_once()
+    assert "A" in result.results
+    assert len(result.results["A"].frames) == 1


### PR DESCRIPTION
This PR adds support for Loki datasource to mcp-grafana and command line options for Grafana URL and API key.

## Changes

- Added LokiSettings class in settings.py
- Created loki.py with query tools (query_loki, list_loki_label_names, list_loki_label_values, query_loki_logs, query_loki_metrics, query_loki_instant)
- Added loki_query_range and loki_query methods to GrafanaClient
- Updated tools/__init__.py to register Loki tools
- Updated README.md to document Loki support
- Added tests for all Loki tools
- Added command line options for Grafana URL and API key in cli.py
- Added tests for CLI options

All tests are passing.